### PR TITLE
General tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN mkdir /app
 RUN ls
 COPY  ./narrative-analytics.jar /app
 
+EXPOSE 8080
 CMD ["java","-jar","/app/narrative-analytics.jar"]

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ This is a solution to a recruitment task for narrative.io
 - setup swagger
 - add unit/integration tests
 
-## How to run
+## How to run locally
 
 - start docker and kafka `docker-compose -f "./local-environment/docker-compose.yml" up`
 - start the application by `sbt run` or `docker run docker.io/piotrkun/analytics:latest`
 - upload the druid ingestion
   spec `curl -X POST -H 'Content-Type: application/json' -d @analytics-v1.json http://localhost:8081/druid/indexer/v1/supervisor`
+
+### [link to local-environment documentation](local-environment/README.md)
 
 ## Docker
 - A docker image is being deployed to `docker.io/piotrkun/analytics:latest` by CI/CD on pushing to master
@@ -68,3 +70,17 @@ building and running it. Although it should still pass muster in code review, it
 completely production ready in the submission. For example, using local storage like in-memory H2 instead of dedicated
 MySQL is OK. As a guide for design decisions, treat this exercise as the initial prototype of an MVP that will need to
 be productionalized and scaled out in the future, and be prepared for follow-up discussion on how that would look.
+
+
+
+-- SELECT
+-- SUM("count") FILTER(WHERE eventType = 'click') AS clicks,  
+-- SUM("count") FILTER(WHERE eventType = 'impression') AS impressions,
+-- COUNT(DISTINCT userId) AS unique_users
+-- FROM "analytics-v1"
+-- WHERE __time >= DATE_TRUNC('hour', MILLIS_TO_TIMESTAMP(1647111111111)) - INTERVAL '1' HOUR and __time <= DATE_TRUNC('hour', MILLIS_TO_TIMESTAMP(1647111111111))
+
+
+
+
+select * from "analytics-v1"

--- a/README.md
+++ b/README.md
@@ -70,17 +70,3 @@ building and running it. Although it should still pass muster in code review, it
 completely production ready in the submission. For example, using local storage like in-memory H2 instead of dedicated
 MySQL is OK. As a guide for design decisions, treat this exercise as the initial prototype of an MVP that will need to
 be productionalized and scaled out in the future, and be prepared for follow-up discussion on how that would look.
-
-
-
--- SELECT
--- SUM("count") FILTER(WHERE eventType = 'click') AS clicks,  
--- SUM("count") FILTER(WHERE eventType = 'impression') AS impressions,
--- COUNT(DISTINCT userId) AS unique_users
--- FROM "analytics-v1"
--- WHERE __time >= DATE_TRUNC('hour', MILLIS_TO_TIMESTAMP(1647111111111)) - INTERVAL '1' HOUR and __time <= DATE_TRUNC('hour', MILLIS_TO_TIMESTAMP(1647111111111))
-
-
-
-
-select * from "analytics-v1"

--- a/analytics-v1.json
+++ b/analytics-v1.json
@@ -31,7 +31,7 @@
     ],
     "granularitySpec": {
       "type": "uniform",
-      "segmentGranularity": "MONTH",
+      "segmentGranularity": "DAY",
       "queryGranularity": "HOUR",
       "intervals": [
         "2022-03-07/2031-12-01"
@@ -41,8 +41,8 @@
   "tuningConfig": {
     "type": "kafka",
     "maxRowsInMemory": 50000,
-    "intermediatePersistPeriod": "PT1M",
-    "maxRowsPerSegment": 5000000
+    "intermediatePersistPeriod": "PT1S",
+    "maxRowsPerSegment": 500000
   },
   "ioConfig": {
     "topic": "analytics-v1",

--- a/src/main/resources/config/application.conf
+++ b/src/main/resources/config/application.conf
@@ -5,7 +5,7 @@ api {
 kafka {
   topic {
     name = analytics-v1
-    numOfPartitions = 18
+    numOfPartitions = 1
     replication = 1
   }
   properties {

--- a/src/main/scala/analytics/kafka/KafkaProducer.scala
+++ b/src/main/scala/analytics/kafka/KafkaProducer.scala
@@ -8,20 +8,26 @@ import analytics.model.Model.{AnalyticsEvent, UserId}
 import io.circe.generic.auto.*
 import io.circe.syntax.*
 import org.apache.kafka.clients.admin.{Admin, NewTopic}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
+import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.*
 
 object KafkaProducer {
-
   val analyticsTopic = new NewTopic(service.kafka.topic.name, service.kafka.topic.numOfPartitions, service.kafka.topic.replication)
   val kafkaAdmin: Admin = Admin.create(service.kafka.properties.asJava)
   val kafkaProducer: KafkaProducer[UserId, String] = new KafkaProducer[UserId, String](service.kafka.properties.asJava)
 
+  def sendMessage(key: UserId, value: AnalyticsEvent) =
+    kafkaProducer.send(new ProducerRecord(analyticsTopic.name(), key, value.asJson.toString), (metadata, exception) =>
+      Option(exception) match
+        case Some(ex) => logger.error(s"Failed to send $value because ${exception.getMessage}", ex)
+        case None => logger.info(s"Successfully send even $value")
+    )
+
   kafkaAdmin.createTopics(List(analyticsTopic).asJava)
 
-  def sendMessage(key: UserId, value: AnalyticsEvent) =
-    kafkaProducer.send(new ProducerRecord(analyticsTopic.name(), key, value.asJson.toString))
+  private def logger = LoggerFactory.getLogger("Kafka")
 
   sys.addShutdownHook(kafkaProducer.flush())
 }


### PR DESCRIPTION
- [Tweaking ingestion spec to persist data from Kafka every 1S instead of every 10m](https://github.com/pleszczy/recruitment-task-for-narrative-scala/commit/871bcc7d601a4fe221ee1ddaf85130b35c0f6c14)
- [Linking local environment README.md](https://github.com/pleszczy/recruitment-task-for-narrative-scala/commit/f619aff00f7546cd352d0396173f3f6c0fae8a68)
- [Adding result loging to kafka producer](https://github.com/pleszczy/recruitment-task-for-narrative-scala/commit/c1297dcba4e2763af57e77155a771b8961fafbab)
- [Exposing port 8080 in Dockerfile](https://github.com/pleszczy/recruitment-task-for-narrative-scala/commit/3967a4f3feaf16235310bd7abf2b8dead8304b80)
- [Decreasing analytics-v1 partitions to 1 for local development](https://github.com/pleszczy/recruitment-task-for-narrative-scala/commit/4c6b8653032792a3fa08cb10a9f9432fa617037b)